### PR TITLE
apply a consistent naming schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Done.
 
 ```
-$ git fetch --all --tags && git checkout tags/v1.0 -b v1.0   # checkout the tag
+$ git fetch --all --tags && git checkout tags/v1.1 -b v1.1   # checkout the tag
 $ cmake -Bbuild -S.                                          # bootstrap the build
 $ cd build
 $ cmake --build .                                            # build stockman-c

--- a/src/csvimport.c
+++ b/src/csvimport.c
@@ -21,16 +21,16 @@
 #include "database.h"
 #include "models.h"
 
-Invoice*
+Models_Invoice*
 invoice_from_csv(gchar **fields);
 
-InvoiceLine*
+Models_InvoiceLine*
 invoice_line_from_csv(gchar **fields);
 
-Invoice*
+Models_Invoice*
 invoice_from_csv(gchar **fields)
 {
-	Invoice *inv = g_malloc(sizeof(Invoice));
+	Models_Invoice *inv = g_malloc(sizeof(Models_Invoice));
 	inv->doc_no = fields[0];
 	inv->customer = fields[1];
 	inv->date = fields[2];
@@ -40,10 +40,10 @@ invoice_from_csv(gchar **fields)
 	return inv;
 }
 
-InvoiceLine*
+Models_InvoiceLine*
 invoice_line_from_csv(gchar **fields)
 {
-	InvoiceLine *iline = g_malloc(sizeof(InvoiceLine));
+	Models_InvoiceLine *iline = g_malloc(sizeof(Models_InvoiceLine));
 	iline->line_no = g_ascii_strtoull(fields[5], NULL, 10);
 	iline->product = fields[6];
 	iline->qty = g_ascii_strtoull(fields[7], NULL, 10);
@@ -57,10 +57,10 @@ CsvImport_processLine(gchar *line)
 {
 	gchar **fields = g_strsplit(line, ",", -1);
 	gchar *doc_no = fields[0];
-	Invoice *inv = Database_Invoice_get(doc_no);
+	Models_Invoice *inv = Database_Invoice_get(doc_no);
 	if (!inv)
 		inv = invoice_from_csv(fields);
-	InvoiceLine *iline = invoice_line_from_csv(fields);
-	Invoice_addLine(inv, iline);
+	Models_InvoiceLine *iline = invoice_line_from_csv(fields);
+	Models_Invoice_addLine(inv, iline);
 	Database_Invoice_save(inv);
 }

--- a/src/csvimport.c
+++ b/src/csvimport.c
@@ -53,14 +53,14 @@ invoice_line_from_csv(gchar **fields)
 }
 
 void
-csvimport_line_process(gchar *line)
+CsvImport_processLine(gchar *line)
 {
 	gchar **fields = g_strsplit(line, ",", -1);
 	gchar *doc_no = fields[0];
-	Invoice *inv = database_invoice_get(doc_no);
+	Invoice *inv = Database_Invoice_get(doc_no);
 	if (!inv)
 		inv = invoice_from_csv(fields);
 	InvoiceLine *iline = invoice_line_from_csv(fields);
-	invoice_add_line(inv, iline);
-	database_invoice_save(inv);
+	Invoice_addLine(inv, iline);
+	Database_Invoice_save(inv);
 }

--- a/src/csvimport.h
+++ b/src/csvimport.h
@@ -40,4 +40,4 @@
  * @param line The line from CSV file
  */
 void
-csvimport_line_process(gchar *line);
+CsvImport_processLine(gchar *line);

--- a/src/database.c
+++ b/src/database.c
@@ -46,12 +46,12 @@ Database_init()
 }
 
 gboolean
-Database_Invoice_save(Invoice *inv)
+Database_Invoice_save(Models_Invoice *inv)
 {
 	return g_hash_table_insert(Database_get()->invoices, inv->doc_no, inv);
 }
 
-Invoice*
+Models_Invoice*
 Database_Invoice_get(gchar *doc_no)
 {
 	return g_hash_table_lookup(Database_get()->invoices, doc_no);
@@ -60,23 +60,23 @@ Database_Invoice_get(gchar *doc_no)
 void
 invoices_foreach(gpointer doc_no, gpointer invp, gpointer thunkp)
 {
-	Invoice *inv = (Invoice *)invp;
-	void (*thunk)(Invoice *) = thunkp;
+	Models_Invoice *inv = (Models_Invoice *)invp;
+	void (*thunk)(Models_Invoice *) = thunkp;
 	thunk(inv);
 }
 
 void
-Database_Invoice_foreach(void (*thunk)(Invoice *))
+Database_Invoice_foreach(void (*thunk)(Models_Invoice *))
 {
 	g_hash_table_foreach(db->invoices, invoices_foreach, thunk);
 }
 
 void
-Database_Invoice_clear(void (*invoice_destroy_thunk)(Invoice *))
+Database_Invoice_clear(void (*invoice_destroy_thunk)(Models_Invoice *))
 {
 	g_autoptr(GList) keys = g_hash_table_get_keys(db->invoices);
 	for (GList *key = keys; key; key = key->next) {
-		Invoice *inv = g_hash_table_lookup(db->invoices, key);
+		Models_Invoice *inv = g_hash_table_lookup(db->invoices, key);
 		if (invoice_destroy_thunk)
 			invoice_destroy_thunk(inv);
 		g_hash_table_remove(db->invoices, key->data);

--- a/src/database.c
+++ b/src/database.c
@@ -24,7 +24,7 @@ typedef struct Database {
 } Database;
 
 const Database*
-database_get()
+Database_get()
 {
 	if (!db) {
 		g_error("database is NOT initialised.\n");
@@ -34,7 +34,7 @@ database_get()
 }
 
 void
-database_init()
+Database_init()
 {
 	if (db) {
 		g_debug("Database already initialised.");
@@ -46,15 +46,15 @@ database_init()
 }
 
 gboolean
-database_invoice_save(Invoice *inv)
+Database_Invoice_save(Invoice *inv)
 {
-	return g_hash_table_insert(database_get()->invoices, inv->doc_no, inv);
+	return g_hash_table_insert(Database_get()->invoices, inv->doc_no, inv);
 }
 
 Invoice*
-database_invoice_get(gchar *doc_no)
+Database_Invoice_get(gchar *doc_no)
 {
-	return g_hash_table_lookup(database_get()->invoices, doc_no);
+	return g_hash_table_lookup(Database_get()->invoices, doc_no);
 }
 
 void
@@ -66,13 +66,13 @@ invoices_foreach(gpointer doc_no, gpointer invp, gpointer thunkp)
 }
 
 void
-database_invoices_foreach(void (*thunk)(Invoice *))
+Database_Invoice_foreach(void (*thunk)(Invoice *))
 {
 	g_hash_table_foreach(db->invoices, invoices_foreach, thunk);
 }
 
 void
-database_invoices_clear(void (*invoice_destroy_thunk)(Invoice *))
+Database_Invoice_clear(void (*invoice_destroy_thunk)(Invoice *))
 {
 	g_autoptr(GList) keys = g_hash_table_get_keys(db->invoices);
 	for (GList *key = keys; key; key = key->next) {

--- a/src/database.h
+++ b/src/database.h
@@ -44,7 +44,7 @@ Database_get();
  * @param doc_no Invoice number
  * @return Invoice if exists, `NULL` otherwise.
  */
-Invoice*
+Models_Invoice*
 Database_Invoice_get(gchar *doc_no);
 
 /**
@@ -57,7 +57,7 @@ Database_Invoice_get(gchar *doc_no);
  * @return `TRUE` if successful, `FALSE` otherwise.
  */
 gboolean
-Database_Invoice_save(Invoice *inv);
+Database_Invoice_save(Models_Invoice *inv);
 
 /**
  * Iterate over all invoices and execute a given thunk for each.
@@ -65,7 +65,7 @@ Database_Invoice_save(Invoice *inv);
  * @param thunk Function to execute for each invoice.
  */
 void
-Database_Invoice_foreach(void (*thunk)(Invoice*));
+Database_Invoice_foreach(void (*thunk)(Models_Invoice*));
 
 /**
  * Remove all invoices from the database.
@@ -74,4 +74,4 @@ Database_Invoice_foreach(void (*thunk)(Invoice*));
  *        mainly to free up the memory.
  */
 void
-Database_Invoice_clear(void (*invoice_destroy_thunk)(Invoice *));
+Database_Invoice_clear(void (*invoice_destroy_thunk)(Models_Invoice *));

--- a/src/database.h
+++ b/src/database.h
@@ -29,14 +29,14 @@ static Database* db;
  * Initialise the database.
  */
 void
-database_init();
+Database_init();
 
 /**
  * Returns the initialised database instance.
  * Attempt to `get` an uninitialised database causes the program to abort.
  */
 const Database*
-database_get();
+Database_get();
 
 /**
  * Find an invoice.
@@ -45,7 +45,7 @@ database_get();
  * @return Invoice if exists, `NULL` otherwise.
  */
 Invoice*
-database_invoice_get(gchar *doc_no);
+Database_Invoice_get(gchar *doc_no);
 
 /**
  * Persist an invoice.
@@ -57,7 +57,7 @@ database_invoice_get(gchar *doc_no);
  * @return `TRUE` if successful, `FALSE` otherwise.
  */
 gboolean
-database_invoice_save(Invoice *inv);
+Database_Invoice_save(Invoice *inv);
 
 /**
  * Iterate over all invoices and execute a given thunk for each.
@@ -65,7 +65,7 @@ database_invoice_save(Invoice *inv);
  * @param thunk Function to execute for each invoice.
  */
 void
-database_invoices_foreach(void (*thunk)(Invoice*));
+Database_Invoice_foreach(void (*thunk)(Invoice*));
 
 /**
  * Remove all invoices from the database.
@@ -74,4 +74,4 @@ database_invoices_foreach(void (*thunk)(Invoice*));
  *        mainly to free up the memory.
  */
 void
-database_invoices_clear(void (*invoice_destroy_thunk)(Invoice *));
+Database_Invoice_clear(void (*invoice_destroy_thunk)(Invoice *));

--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@ file_get_lines(char *filepath, GError **error)
 void
 invoice_pretty_print(Invoice *inv)
 {
-	inv->lines = g_list_sort(inv->lines, invoice_line_compare_by_line_no);
+	inv->lines = g_list_sort(inv->lines, InvoiceLine_compareByLineNo);
 	g_print("\n"
 	        "+------------------------------------------------------------------------------+\n"
 	        "| INVOICE#: %-35s  DATE:       %-10s        |\n"
@@ -73,14 +73,14 @@ main(int argc, char **argv)
 		return 0;
 	}
 	g_log_set_writer_func(g_log_writer_standard_streams, NULL, NULL);
-	database_init();
+	Database_init();
 
 	g_autoptr(GError) error = NULL;
 	gchar **lines;
 	if (!(lines = file_get_lines(argv[1], &error)))
 		g_error("ERROR: %s\n", error->message);
 	for (int line=0; lines[line]; line++)
-		csvimport_line_process(lines[line]);
-	database_invoices_foreach(invoice_pretty_print);
+		CsvImport_processLine(lines[line]);
+	Database_Invoice_foreach(invoice_pretty_print);
 	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -27,7 +27,7 @@ gchar**
 file_get_lines(char *filepath, GError **error);
 
 void
-invoice_pretty_print(Invoice *inv);
+invoice_pretty_print(Models_Invoice *inv);
 
 gchar**
 file_get_lines(char *filepath, GError **error)
@@ -41,9 +41,9 @@ file_get_lines(char *filepath, GError **error)
 }
 
 void
-invoice_pretty_print(Invoice *inv)
+invoice_pretty_print(Models_Invoice *inv)
 {
-	inv->lines = g_list_sort(inv->lines, InvoiceLine_compareByLineNo);
+	inv->lines = g_list_sort(inv->lines, Models_InvoiceLine_compareByLineNo);
 	g_print("\n"
 	        "+------------------------------------------------------------------------------+\n"
 	        "| INVOICE#: %-35s  DATE:       %-10s        |\n"
@@ -54,7 +54,7 @@ invoice_pretty_print(Invoice *inv)
 	        inv->doc_no, inv->date,
 	        inv->customer, inv->discount);
 	for (GList *iline = inv->lines; iline; iline = iline->next) {
-		InvoiceLine *data = iline->data;
+		Models_InvoiceLine *data = iline->data;
 		g_print("| %3d   %-26s     %8d   %10.2f   %15.2f |\n",
 		        data->line_no, data->product,
 		        data->qty, data->price, data->line_amt);

--- a/src/models.c
+++ b/src/models.c
@@ -20,14 +20,14 @@
 #include "models.h"
 
 void
-invoice_add_line(Invoice *inv, InvoiceLine *iline)
+Invoice_addLine(Invoice *inv, InvoiceLine *iline)
 {
 	inv->lines = g_list_prepend(inv->lines, iline);
 }
 
 
 gint
-invoice_line_compare_by_line_no(gconstpointer iline_vptr, gconstpointer other_vptr)
+InvoiceLine_compareByLineNo(gconstpointer iline_vptr, gconstpointer other_vptr)
 {
 	InvoiceLine *iline = (InvoiceLine *)iline_vptr;
 	InvoiceLine *other = (InvoiceLine *)other_vptr;

--- a/src/models.c
+++ b/src/models.c
@@ -20,17 +20,17 @@
 #include "models.h"
 
 void
-Invoice_addLine(Invoice *inv, InvoiceLine *iline)
+Models_Invoice_addLine(Models_Invoice *inv, Models_InvoiceLine *iline)
 {
 	inv->lines = g_list_prepend(inv->lines, iline);
 }
 
 
 gint
-InvoiceLine_compareByLineNo(gconstpointer iline_vptr, gconstpointer other_vptr)
+Models_InvoiceLine_compareByLineNo(gconstpointer iline_vptr, gconstpointer other_vptr)
 {
-	InvoiceLine *iline = (InvoiceLine *)iline_vptr;
-	InvoiceLine *other = (InvoiceLine *)other_vptr;
+	Models_InvoiceLine *iline = (Models_InvoiceLine *)iline_vptr;
+	Models_InvoiceLine *other = (Models_InvoiceLine *)other_vptr;
 	if (iline->line_no < other->line_no)
 		return -1;
 	else if (iline->line_no == other->line_no)

--- a/src/models.h
+++ b/src/models.h
@@ -44,7 +44,7 @@ typedef struct Invoice {
  * @param iline Invoice line
  */
 void
-invoice_add_line(Invoice *inv, InvoiceLine *iline);
+Invoice_addLine(Invoice *inv, InvoiceLine *iline);
 
 /**
  * Compare a given invoice line with another line by `line_no`.
@@ -55,4 +55,4 @@ invoice_add_line(Invoice *inv, InvoiceLine *iline);
  *         equal and 1 if the given invoice line has a larger `line_no`.
  */
 gint
-invoice_line_compare_by_line_no(gconstpointer iline, gconstpointer other);
+InvoiceLine_compareByLineNo(gconstpointer iline, gconstpointer other);

--- a/src/models.h
+++ b/src/models.h
@@ -20,22 +20,22 @@
 
 #include <glib.h>
 
-typedef struct InvoiceLine {
+typedef struct Models_InvoiceLine {
 	guint line_no;
 	gchar *product;
 	guint qty;
 	gdouble price;
 	gdouble line_amt;
-} InvoiceLine;
+} Models_InvoiceLine;
 
-typedef struct Invoice {
+typedef struct Models_Invoice {
 	gchar *doc_no;
 	gchar *customer;
 	gchar *date;
 	gdouble total;
 	gdouble discount;
 	GList *lines;
-} Invoice;
+} Models_Invoice;
 
 /**
  * Add a line to the invoice.
@@ -44,7 +44,7 @@ typedef struct Invoice {
  * @param iline Invoice line
  */
 void
-Invoice_addLine(Invoice *inv, InvoiceLine *iline);
+Models_Invoice_addLine(Models_Invoice *inv, Models_InvoiceLine *iline);
 
 /**
  * Compare a given invoice line with another line by `line_no`.
@@ -55,4 +55,4 @@ Invoice_addLine(Invoice *inv, InvoiceLine *iline);
  *         equal and 1 if the given invoice line has a larger `line_no`.
  */
 gint
-InvoiceLine_compareByLineNo(gconstpointer iline, gconstpointer other);
+Models_InvoiceLine_compareByLineNo(gconstpointer iline, gconstpointer other);

--- a/tests/csvimport_tests.c
+++ b/tests/csvimport_tests.c
@@ -36,7 +36,7 @@ database_teardown()
 gboolean
 invoice_line_has_line_no(const void *iline_vptr, const void *line_no_vptr)
 {
-	InvoiceLine *iline = (InvoiceLine *)iline_vptr;
+	Models_InvoiceLine *iline = (Models_InvoiceLine *)iline_vptr;
 	guint line_no = *(guint *)line_no_vptr;
 	if (line_no == iline->line_no)
 		return TRUE;
@@ -57,7 +57,7 @@ test_CsvImport_processLine__existing_invoice()
 	CsvImport_processLine(csvline2);
 
 	/* THEN */
-	Invoice *inv = Database_Invoice_get("SI-862");
+	Models_Invoice *inv = Database_Invoice_get("SI-862");
 	g_assert_nonnull(inv);
 	g_assert_cmpstr("SI-862", ==, inv->doc_no);
 	g_assert_cmpstr("C-114", ==, inv->customer);
@@ -70,7 +70,7 @@ test_CsvImport_processLine__existing_invoice()
 	guint line_no = 2;
 	GList *node = g_list_find_custom(inv->lines, &line_no, invoice_line_has_line_no);
 	g_assert_nonnull(node);
-	InvoiceLine *iline = node->data;
+	Models_InvoiceLine *iline = node->data;
 	g_assert_cmpint(1, ==, iline->line_no);
 	g_assert_cmpstr("P-7964", ==, iline->product);
 	g_assert_cmpint(192, ==, iline->qty);
@@ -89,7 +89,7 @@ test_CsvImport_processLine__new_invoice()
 	CsvImport_processLine(csvline);
 
 	/* THEN */
-	Invoice *inv = Database_Invoice_get("SI-862");
+	Models_Invoice *inv = Database_Invoice_get("SI-862");
 	g_assert_nonnull(inv);
 	g_assert_cmpstr("SI-862", ==, inv->doc_no);
 	g_assert_cmpstr("C-114", ==, inv->customer);
@@ -99,7 +99,7 @@ test_CsvImport_processLine__new_invoice()
 
 	g_assert_nonnull(inv->lines);
 	g_assert_cmpint(1, ==, g_list_length(inv->lines));
-	InvoiceLine *iline = inv->lines->data;
+	Models_InvoiceLine *iline = inv->lines->data;
 	g_assert_cmpint(1, ==, iline->line_no);
 	g_assert_cmpstr("P-7964", ==, iline->product);
 	g_assert_cmpint(192, ==, iline->qty);

--- a/tests/csvimport_tests.c
+++ b/tests/csvimport_tests.c
@@ -24,13 +24,13 @@
 void
 database_setup()
 {
-	database_init();
+	Database_init();
 }
 
 void
 database_teardown()
 {
-	database_invoices_clear(NULL);
+	Database_Invoice_clear(NULL);
 }
 
 gboolean
@@ -45,7 +45,7 @@ invoice_line_has_line_no(const void *iline_vptr, const void *line_no_vptr)
 }
 
 void
-test_csvimport_line_process__existing_invoice()
+test_CsvImport_processLine__existing_invoice()
 {
 	/* GIVEN */
 	gchar *csvline1 = "SI-862,C-114,2016/10/16,8707.20,29,1,P-7964,192,4.33,831.36";
@@ -53,11 +53,11 @@ test_csvimport_line_process__existing_invoice()
 	// database is empty
 
 	/* WHEN */
-	csvimport_line_process(csvline1);
-	csvimport_line_process(csvline2);
+	CsvImport_processLine(csvline1);
+	CsvImport_processLine(csvline2);
 
 	/* THEN */
-	Invoice *inv = database_invoice_get("SI-862");
+	Invoice *inv = Database_Invoice_get("SI-862");
 	g_assert_nonnull(inv);
 	g_assert_cmpstr("SI-862", ==, inv->doc_no);
 	g_assert_cmpstr("C-114", ==, inv->customer);
@@ -79,17 +79,17 @@ test_csvimport_line_process__existing_invoice()
 }
 
 void
-test_csvimport_line_process__new_invoice()
+test_CsvImport_processLine__new_invoice()
 {
 	/* GIVEN */
 	gchar *csvline = "SI-862,C-114,2016/10/16,8707.20,29,1,P-7964,192,4.33,831.36";
 	// database is empty
 
 	/* WHEN */
-	csvimport_line_process(csvline);
+	CsvImport_processLine(csvline);
 
 	/* THEN */
-	Invoice *inv = database_invoice_get("SI-862");
+	Invoice *inv = Database_Invoice_get("SI-862");
 	g_assert_nonnull(inv);
 	g_assert_cmpstr("SI-862", ==, inv->doc_no);
 	g_assert_cmpstr("C-114", ==, inv->customer);
@@ -111,11 +111,11 @@ int
 main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
-	g_test_add("/csvimport/line_process/new_invoice",
+	g_test_add("/CsvImport/processLine/new_invoice",
 	           gpointer, NULL,
-	           database_setup, test_csvimport_line_process__new_invoice, database_teardown);
-	g_test_add("/csvimport/line_process/existing_invoice",
+	           database_setup, test_CsvImport_processLine__new_invoice, database_teardown);
+	g_test_add("/CsvImport/processLine/existing_invoice",
 	           gpointer, NULL,
-	           database_setup, test_csvimport_line_process__existing_invoice, database_teardown);
+	           database_setup, test_CsvImport_processLine__existing_invoice, database_teardown);
 	return g_test_run();
 }

--- a/tests/database_tests.c
+++ b/tests/database_tests.c
@@ -36,13 +36,13 @@ void
 test_Database_Invoice_get_and_save()
 {
 	/* GIVEN */
-	Invoice inv = {.doc_no = "I1", .lines = NULL};
+	Models_Invoice inv = {.doc_no = "I1", .lines = NULL};
 
 	/* WHEN */
 	Database_Invoice_save(&inv);
 
 	/* THEN */
-	Invoice *actual = Database_Invoice_get("I1");
+	Models_Invoice *actual = Database_Invoice_get("I1");
 	g_assert_cmpstr("I1", ==, actual->doc_no);
 }
 
@@ -50,7 +50,7 @@ guint invoices_foreach_thunk_counter  = 0;
 gchar *invoices_foreach_thunk_doc_nos[2] = {NULL, NULL};
 
 void
-invoices_foreach_thunk(Invoice * inv)
+invoices_foreach_thunk(Models_Invoice * inv)
 {
 	invoices_foreach_thunk_doc_nos[invoices_foreach_thunk_counter] = inv->doc_no;
 	invoices_foreach_thunk_counter += 1;
@@ -60,9 +60,9 @@ void
 test_Database_Invoice_foreach()
 {
 	/* GIVEN */
-	Invoice inv1 = {.doc_no = "I1", .lines = NULL};
+	Models_Invoice inv1 = {.doc_no = "I1", .lines = NULL};
 	Database_Invoice_save(&inv1);
-	Invoice inv2 = {.doc_no = "I2", .lines = NULL};
+	Models_Invoice inv2 = {.doc_no = "I2", .lines = NULL};
 	Database_Invoice_save(&inv2);
 
 	/* WHEN */
@@ -80,7 +80,7 @@ void
 test_Database_Invoice_clear()
 {
 	/* GIVEN */
-	Invoice inv1 = {.doc_no = "I1", .lines = NULL};
+	Models_Invoice inv1 = {.doc_no = "I1", .lines = NULL};
 	Database_Invoice_save(&inv1);
 
 	/* WHEN */

--- a/tests/database_tests.c
+++ b/tests/database_tests.c
@@ -23,26 +23,26 @@
 void
 database_setup()
 {
-	database_init();
+	Database_init();
 }
 
 void
 database_teardown()
 {
-	database_invoices_clear(NULL);
+	Database_Invoice_clear(NULL);
 }
 
 void
-test_database_invoice_get_and_save()
+test_Database_Invoice_get_and_save()
 {
 	/* GIVEN */
 	Invoice inv = {.doc_no = "I1", .lines = NULL};
 
 	/* WHEN */
-	database_invoice_save(&inv);
+	Database_Invoice_save(&inv);
 
 	/* THEN */
-	Invoice *actual = database_invoice_get("I1");
+	Invoice *actual = Database_Invoice_get("I1");
 	g_assert_cmpstr("I1", ==, actual->doc_no);
 }
 
@@ -57,16 +57,16 @@ invoices_foreach_thunk(Invoice * inv)
 }
 
 void
-test_database_invoices_foreach()
+test_Database_Invoice_foreach()
 {
 	/* GIVEN */
 	Invoice inv1 = {.doc_no = "I1", .lines = NULL};
-	database_invoice_save(&inv1);
+	Database_Invoice_save(&inv1);
 	Invoice inv2 = {.doc_no = "I2", .lines = NULL};
-	database_invoice_save(&inv2);
+	Database_Invoice_save(&inv2);
 
 	/* WHEN */
-	database_invoices_foreach(invoices_foreach_thunk);
+	Database_Invoice_foreach(invoices_foreach_thunk);
 
 	/* THEN */
 	g_assert_cmpint(2, ==, invoices_foreach_thunk_counter);
@@ -77,31 +77,31 @@ test_database_invoices_foreach()
 }
 
 void
-test_database_invoices_clear()
+test_Database_Invoice_clear()
 {
 	/* GIVEN */
 	Invoice inv1 = {.doc_no = "I1", .lines = NULL};
-	database_invoice_save(&inv1);
+	Database_Invoice_save(&inv1);
 
 	/* WHEN */
-	database_invoices_clear(NULL);
+	Database_Invoice_clear(NULL);
 
 	/* THEN */
-	g_assert_null(database_invoice_get("I1"));
+	g_assert_null(Database_Invoice_get("I1"));
 }
 
 int
 main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
-	g_test_add("/database/invoices/get_and_save",
+	g_test_add("/Database/Invoice/get_and_save",
 	           gpointer, NULL,
-	           database_setup, test_database_invoice_get_and_save, database_teardown);
-	g_test_add("/database/invoices/foreach",
+	           database_setup, test_Database_Invoice_get_and_save, database_teardown);
+	g_test_add("/Database/Invoice/foreach",
 	           gpointer, NULL,
-	           database_setup, test_database_invoices_foreach, database_teardown);
-	g_test_add("/database/invoices/clear",
+	           database_setup, test_Database_Invoice_foreach, database_teardown);
+	g_test_add("/Database/Invoice/clear",
 	           gpointer, NULL,
-	           database_setup, test_database_invoices_clear, database_teardown);
+	           database_setup, test_Database_Invoice_clear, database_teardown);
 	return g_test_run();
 }

--- a/tests/models_tests.c
+++ b/tests/models_tests.c
@@ -20,7 +20,7 @@
 #include "models.h"
 
 void
-test_invoice_add_line()
+test_Invoice_addLine()
 {
 	// GIVEN
 	Invoice inv = {.lines = NULL};
@@ -31,7 +31,7 @@ test_invoice_add_line()
 	g_assert_null(inv.lines);
 
 	// WHEN
-	invoice_add_line(&inv, &iline1);
+	Invoice_addLine(&inv, &iline1);
 
 	// THEN
 	g_assert_nonnull(inv.lines);
@@ -39,7 +39,7 @@ test_invoice_add_line()
 	g_assert_nonnull(g_list_find(inv.lines, &iline1));
 
 	// WHEN
-	invoice_add_line(&inv, &iline2);
+	Invoice_addLine(&inv, &iline2);
 
 	// THEN
 	g_assert_cmpint(2, ==, g_list_length(inv.lines));
@@ -48,25 +48,25 @@ test_invoice_add_line()
 }
 
 void
-test_invoice_line_compare_by_line_no()
+test_InvoiceLine_compareByLineNo()
 {
 	// GIVEN
 	InvoiceLine iline1 = {.line_no = 10};
 	InvoiceLine iline2 = {.line_no = 20};
 
 	// EXPECT
-	g_assert_cmpint(0, ==, invoice_line_compare_by_line_no(&iline1, &iline1));
-	g_assert_cmpint(0, >, invoice_line_compare_by_line_no(&iline1, &iline2));
-	g_assert_cmpint(0, <, invoice_line_compare_by_line_no(&iline2, &iline1));
+	g_assert_cmpint(0, ==, InvoiceLine_compareByLineNo(&iline1, &iline1));
+	g_assert_cmpint(0, >, InvoiceLine_compareByLineNo(&iline1, &iline2));
+	g_assert_cmpint(0, <, InvoiceLine_compareByLineNo(&iline2, &iline1));
 }
 
 int
 main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
-	g_test_add_func("/models/invoice/invoice_add_line",
-	                test_invoice_add_line);
-	g_test_add_func("/models/invoice/invoice_line_compare_by_line_no",
-	                test_invoice_line_compare_by_line_no);
+	g_test_add_func("/models/Invoice/addLine",
+	                test_Invoice_addLine);
+	g_test_add_func("/models/InvoiceLine/compareByLineNo",
+	                test_InvoiceLine_compareByLineNo);
 	return g_test_run();
 }

--- a/tests/models_tests.c
+++ b/tests/models_tests.c
@@ -23,15 +23,15 @@ void
 test_Invoice_addLine()
 {
 	// GIVEN
-	Invoice inv = {.lines = NULL};
-	InvoiceLine iline1 = {.line_no = 10, .product = "P1"};
-	InvoiceLine iline2 = {.line_no = 20, .product = "P2"};
+	Models_Invoice inv = {.lines = NULL};
+	Models_InvoiceLine iline1 = {.line_no = 10, .product = "P1"};
+	Models_InvoiceLine iline2 = {.line_no = 20, .product = "P2"};
 
 	// EXPECT
 	g_assert_null(inv.lines);
 
 	// WHEN
-	Invoice_addLine(&inv, &iline1);
+	Models_Invoice_addLine(&inv, &iline1);
 
 	// THEN
 	g_assert_nonnull(inv.lines);
@@ -39,7 +39,7 @@ test_Invoice_addLine()
 	g_assert_nonnull(g_list_find(inv.lines, &iline1));
 
 	// WHEN
-	Invoice_addLine(&inv, &iline2);
+	Models_Invoice_addLine(&inv, &iline2);
 
 	// THEN
 	g_assert_cmpint(2, ==, g_list_length(inv.lines));
@@ -51,13 +51,13 @@ void
 test_InvoiceLine_compareByLineNo()
 {
 	// GIVEN
-	InvoiceLine iline1 = {.line_no = 10};
-	InvoiceLine iline2 = {.line_no = 20};
+	Models_InvoiceLine iline1 = {.line_no = 10};
+	Models_InvoiceLine iline2 = {.line_no = 20};
 
 	// EXPECT
-	g_assert_cmpint(0, ==, InvoiceLine_compareByLineNo(&iline1, &iline1));
-	g_assert_cmpint(0, >, InvoiceLine_compareByLineNo(&iline1, &iline2));
-	g_assert_cmpint(0, <, InvoiceLine_compareByLineNo(&iline2, &iline1));
+	g_assert_cmpint(0, ==, Models_InvoiceLine_compareByLineNo(&iline1, &iline1));
+	g_assert_cmpint(0, >, Models_InvoiceLine_compareByLineNo(&iline1, &iline2));
+	g_assert_cmpint(0, <, Models_InvoiceLine_compareByLineNo(&iline2, &iline1));
 }
 
 int


### PR DESCRIPTION
- a function like `Foo_Bar_someFunc` means that `someFunc` belongs to `Bar` module/entity which belongs to `Foo` module/entity and it is defined in either `Foo.c` or `Foo/Bar.c`
- a function `anotherFunc` means a module-private function which is not to be exposed.
- a struct/union named `Foo_Bar_Baz` means `Baz` belongs to `Bar` entity which belongs to `Foo`.  `Baz` is defined in either `Foo/Bar.c` or `Foo.c`.